### PR TITLE
Refactor Element and Component classes

### DIFF
--- a/lion_core/abc/concept.py
+++ b/lion_core/abc/concept.py
@@ -14,12 +14,12 @@ class AbstractSpace(ABC):
 class AbstractElement(ABC):
     """An abstract observable entity in a space."""
 
-    @abstractmethod
-    def convert_to(self, new_type: type | str = "dict", **kwargs) -> Any: ...
-
-    @classmethod
-    @abstractmethod
-    def convert_from(cls, data, new_type: type | str = "dict", **kwargs) -> Any: ...
+    # @abstractmethod
+    # def convert_to(self, new_type: type | str = "dict", **kwargs) -> Any: ...
+    #
+    # @classmethod
+    # @abstractmethod
+    # def convert_from(cls, data, new_type: type | str = "dict", **kwargs) -> Any: ...
 
 
 class AbstractObserver(ABC):

--- a/lion_core/abc/element.py
+++ b/lion_core/abc/element.py
@@ -100,25 +100,6 @@ class Element(BaseModel, AbstractElement, Observable, Temporal):
         LION_CLASS_REGISTRY[cls.__name__] = cls
 
     @classmethod
-    def _get_class(cls, class_name: str) -> type[Element]:
-        """
-        Retrieve a class by name from the registry or dynamically import it.
-
-        This method uses the get_class utility function to find and return
-        the requested class, ensuring it's a subclass of Element.
-
-        Args:
-            class_name: The name of the class to retrieve.
-
-        Returns:
-            The requested class.
-
-        Raises:
-            ValueError: If the class is not found or not a subclass of Element.
-        """
-        return get_class(class_name, Element)
-
-    @classmethod
     def class_name(cls) -> str:
         """
         Get the name of the class.


### PR DESCRIPTION
This commit includes several changes across multiple files:

1. lion_core/abc/concept.py:
   - Comment out abstract methods convert_to and convert_from in AbstractElement

2. lion_core/abc/element.py:
   - Remove _get_class method from Element class

3. lion_core/generic/component.py:
   - Remove _get_class method from Component class
   - Refactor add_field and update_field methods:
     * Combine functionality to reduce code duplication
     * Improve handling of field objects and annotations * Remove redundant 'default' parameter from add_field

These changes aim to simplify class hierarchies, improve field management in the Component class, and update the project's ignored files. The removal of _get_class methods suggests a shift in how classes are retrieved or managed within the project.