### PR TITLE
Fix GitHub workflows to correctly find tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         pip install -r requirements.txt
         pip install pytest-asyncio
     - name: Run tests
-      run: pytest tests/
+      run: pytest --maxfail=1 --disable-warnings tests/
     - name: Check code style and compatibility
       run: |
         pip install black isort flake8 vermin

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 

--- a/.github/workflows/pc_check.yml
+++ b/.github/workflows/pc_check.yml
@@ -33,9 +33,9 @@ jobs:
         pip install sphinx sphinx_rtd_theme
         cd docs && make html
     - name: Run tests
-      run: pytest tests/
+      run: pytest --maxfail=1 --disable-warnings tests/
     - name: Run tests with pytest-asyncio
-      run: pytest --asyncio-mode=auto tests/
+      run: pytest --asyncio-mode=auto --maxfail=1 --disable-warnings tests/
     - name: Check for sensitive data
       uses: gitleaks/gitleaks-action@v2
       env:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To set up the development environment for Lion-Core, follow these steps:
 
 4. **Run the tests**:
     ```bash
-    pytest
+    pytest --maxfail=1 --disable-warnings tests/
     ```
 
 5. **Check code style**:


### PR DESCRIPTION
Update GitHub workflows to correctly find and run tests.

* **README.md**
  - Update the test command to `pytest --maxfail=1 --disable-warnings tests/`.

* **.github/workflows/ci.yml**
  - Update the `Run tests` step to use `pytest --maxfail=1 --disable-warnings tests/`.

* **.github/workflows/pc_check.yml**
  - Update the `Run tests` step to use `pytest --maxfail=1 --disable-warnings tests/`.
  - Update the `Run tests with pytest-asyncio` step to use `pytest --asyncio-mode=auto --maxfail=1 --disable-warnings tests/`.

* **.github/workflows/codeql-analysis.yml**
  - Update the `Initialize CodeQL` step to use `github/codeql-action/init@v3`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lion-agi/lion-core?shareId=beeb0beb-f65a-45da-9e94-6aab7b48217e).